### PR TITLE
remove dependency on colored

### DIFF
--- a/lib/rails_best_practices.rb
+++ b/lib/rails_best_practices.rb
@@ -2,6 +2,7 @@
 require 'code_analyzer'
 require 'require_all'
 require 'rails_best_practices/core'
+require 'rails_best_practices/colorize'
 require 'rails_best_practices/analyzer'
 require 'rails_best_practices/lexicals'
 require 'rails_best_practices/prepares'

--- a/lib/rails_best_practices/analyzer.rb
+++ b/lib/rails_best_practices/analyzer.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require 'colored'
 require 'fileutils'
 require 'json'
 require 'ruby-progressbar'
@@ -308,8 +307,16 @@ module RailsBestPractices
       if @options["without-color"]
         puts message
       else
-        puts message.send(color)
+        puts self.send(color, message)
       end
+    end
+
+    def red(message)
+      "\e[31m#{message}\e[0m"
+    end
+
+    def green(message)
+      "\e[42m#{message}\e[0m"
     end
 
     # analyze source codes.

--- a/lib/rails_best_practices/analyzer.rb
+++ b/lib/rails_best_practices/analyzer.rb
@@ -307,16 +307,8 @@ module RailsBestPractices
       if @options["without-color"]
         puts message
       else
-        puts self.send(color, message)
+        puts Colorize.send(color, message)
       end
-    end
-
-    def red(message)
-      "\e[31m#{message}\e[0m"
-    end
-
-    def green(message)
-      "\e[32m#{message}\e[0m"
     end
 
     # analyze source codes.

--- a/lib/rails_best_practices/analyzer.rb
+++ b/lib/rails_best_practices/analyzer.rb
@@ -316,7 +316,7 @@ module RailsBestPractices
     end
 
     def green(message)
-      "\e[42m#{message}\e[0m"
+      "\e[32m#{message}\e[0m"
     end
 
     # analyze source codes.

--- a/lib/rails_best_practices/colorize.rb
+++ b/lib/rails_best_practices/colorize.rb
@@ -1,0 +1,11 @@
+module RailsBestPractices
+  class Colorize
+    def self.red(message)
+      "\e[31m#{message}\e[0m"
+    end
+
+    def self.green(message)
+      "\e[32m#{message}\e[0m"
+    end
+  end
+end

--- a/rails_best_practices.gemspec
+++ b/rails_best_practices.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activesupport")
   s.add_dependency("code_analyzer", ">= 0.4.3")
-  s.add_dependency("colored")
   s.add_dependency("erubis")
   s.add_dependency("i18n")
   s.add_dependency("require_all")

--- a/spec/rails_best_practices/analyzer_spec.rb
+++ b/spec/rails_best_practices/analyzer_spec.rb
@@ -104,7 +104,7 @@ module RailsBestPractices
         expect(result).to eq([
           "\e[31mapp/models/user.rb:10 - law of demeter\e[0m",
           "\e[31mapp/models/post.rb:100 - use query attribute\e[0m",
-          "\e[42m\nPlease go to http://rails-bestpractices.com to see more useful Rails Best Practices.\e[0m",
+          "\e[32m\nPlease go to http://rails-bestpractices.com to see more useful Rails Best Practices.\e[0m",
           "\e[31m\nFound 2 warnings.\e[0m"].join("\n") + "\n")
       end
     end

--- a/spec/rails_best_practices/analyzer_spec.rb
+++ b/spec/rails_best_practices/analyzer_spec.rb
@@ -101,7 +101,11 @@ module RailsBestPractices
         subject.output_terminal_errors
         result = $stdout.string
         $stdout = $origin_stdout
-        expect(result).to eq(["app/models/user.rb:10 - law of demeter".red, "app/models/post.rb:100 - use query attribute".red, "\nPlease go to http://rails-bestpractices.com to see more useful Rails Best Practices.".green, "\nFound 2 warnings.".red].join("\n") + "\n")
+        expect(result).to eq([
+          "\e[31mapp/models/user.rb:10 - law of demeter\e[0m",
+          "\e[31mapp/models/post.rb:100 - use query attribute\e[0m",
+          "\e[42m\nPlease go to http://rails-bestpractices.com to see more useful Rails Best Practices.\e[0m",
+          "\e[31m\nFound 2 warnings.\e[0m"].join("\n") + "\n")
       end
     end
 


### PR DESCRIPTION
hey,

i encountered a problem where i can't use the rails best practices gem and konacha together because both are overwriting `String#colorize` with different implementations.

i checked the RBP really quick and saw that only red and green are used. 

this PR removes the `colored` gem and add 2 simple methods that colorize the output in the same way as before.

monkey patching core classes is :hankey: 

thanks for your awesome work!