### PR TITLE
CheckDestroyReturnValueReview

### DIFF
--- a/lib/rails_best_practices/reviews/check_destroy_return_value_review.rb
+++ b/lib/rails_best_practices/reviews/check_destroy_return_value_review.rb
@@ -1,0 +1,60 @@
+# encoding: utf-8
+module RailsBestPractices
+  module Reviews
+    # Review all code to make sure we either check the return value of "destroy"
+    # or use "destroy!"
+    #
+    # Review process:
+    #   Track which nodes are used by 'if', 'unless', '&&' nodes etc. as we pass them by.
+    #   Check all "save" calls to check the return value is used by a node we have visited.
+    class CheckDestroyReturnValueReview < Review
+      include Classable
+      interesting_nodes :call, :command_call, :method_add_arg, :if, :ifop, :elsif, :unless, :if_mod, :unless_mod, :assign, :binary
+      interesting_files ALL_FILES
+
+      add_callback :start_if, :start_ifop, :start_elsif, :start_unless, :start_if_mod, :start_unless_mod do |node|
+        @used_return_value_of = node.conditional_statement.all_conditions
+      end
+
+      add_callback :start_assign do |node|
+        @used_return_value_of = node.right_value
+      end
+
+      add_callback :start_binary do |node|
+        # Consider anything used in an expression like "A or B" as used
+        if %w(&& || and or).include?(node[2].to_s)
+          all_conditions = node.all_conditions
+          # if our current binary is a subset of the @used_return_value_of
+          # then don't overwrite it
+          already_included = @used_return_value_of &&
+            (all_conditions - @used_return_value_of).empty?
+
+          @used_return_value_of = node.all_conditions unless already_included
+        end
+      end
+
+      def return_value_is_used? node
+        return false unless @used_return_value_of
+        node == @used_return_value_of or @used_return_value_of.include?(node)
+      end
+
+      def model_classnames
+        @model_classnames ||= models.map(&:to_s)
+      end
+
+      add_callback :start_call, :start_command_call, :start_method_add_arg do |node|
+        unless @already_checked == node
+          message = node.message.to_s
+          if message.eql? 'destroy'
+            unless return_value_is_used? node
+              add_error "check '#{message}' return value or use '#{message}!'"
+            end
+          end
+          if node.sexp_type == :method_add_arg
+            @already_checked = node[1]
+          end
+        end
+      end
+    end
+  end
+end

--- a/rails_best_practices.yml
+++ b/rails_best_practices.yml
@@ -1,6 +1,7 @@
 AddModelVirtualAttributeCheck: { }
 AlwaysAddDbIndexCheck: { }
 #CheckSaveReturnValueCheck: { }
+#CheckDestroyReturnValueCheck: { }
 DefaultScopeIsEvilCheck: { }
 DryBundlerInCapistranoCheck: { }
 #HashSyntaxCheck: { }

--- a/spec/rails_best_practices/reviews/check_destroy_return_value_spec.rb
+++ b/spec/rails_best_practices/reviews/check_destroy_return_value_spec.rb
@@ -1,0 +1,151 @@
+require 'spec_helper'
+
+module RailsBestPractices
+  module Reviews
+    describe CheckDestroyReturnValueReview do
+      let(:runner) { Core::Runner.new(reviews: CheckDestroyReturnValueReview.new) }
+
+      describe "check_destroy_return_value" do
+        it "should warn you if you fail to check the destroy return value" do
+          content =<<-EOF
+          def my_method
+            post = Posts.create do |p|
+              p.title = "foo"
+            end
+            post.destroy
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(1)
+          expect(runner.errors[0].to_s).to eq("app/helpers/posts_helper.rb:5 - check 'destroy' return value or use 'destroy!'")
+        end
+
+        it "should allow destroy return value if assigned to a var" do
+          content =<<-EOF
+          def my_method
+            post = Posts.create do |p|
+              p.title = "foo"
+            end
+            check_this_later = post.destroy
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(0)
+        end
+
+        it "should allow destroy return value used in if" do
+          content =<<-EOF
+          def my_method
+            post = Posts.create do |p|
+              p.title = "foo"
+            end
+            if post.destroy
+              "OK"
+            else
+              raise "could not delete"
+            end
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(0)
+        end
+
+        it "should allow destroy return value used in elsif" do
+          content =<<-EOF
+          def my_method
+            post = Posts.create do |p|
+              p.title = "foo"
+            end
+            if current_user
+              "YES"
+            elsif post.destroy
+              "OK"
+            else
+              raise "could not delete"
+            end
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(0)
+        end
+
+        it "should allow destroy return value used in unless" do
+          content =<<-EOF
+          def my_method
+            unless @post.destroy
+              raise "could not destroy"
+            end
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(0)
+        end
+
+        it "should allow destroy return value used in if_mod" do
+          content =<<-EOF
+          def my_method
+            post = Posts.create do |p|
+              p.title = "foo"
+            end
+            "OK" if post.destroy
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(0)
+        end
+
+        it "should allow destroy return value used in unless_mod" do
+          content =<<-EOF
+          def my_method
+            post = Posts.create do |p|
+              p.title = "foo"
+            end
+            "NO" unless post.destroy
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(0)
+        end
+
+        it "should allow destroy return value used in unless with &&" do
+          content =<<-EOF
+          def my_method
+            unless some_method(1) && other_method(2) && @post.destroy
+              raise "could not destroy"
+            end
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(0)
+        end
+
+        it "should allow destroy!" do
+          content =<<-EOF
+          def my_method
+            post = Posts.create do |p|
+              p.title = "foo"
+            end
+            post.destroy!
+          end
+          EOF
+          runner.review('app/helpers/posts_helper.rb', content)
+          expect(runner.errors.size).to eq(0)
+        end
+      end
+
+      it "should not check ignored files" do
+        runner = Core::Runner.new(reviews: CheckDestroyReturnValueReview.new(ignored_files: /helpers/))
+        content =<<-EOF
+          def my_method
+            post = Posts.create do |p|
+              p.title = "foo"
+            end
+            post.destroy
+          end
+        EOF
+        runner.review('app/helpers/posts_helper.rb', content)
+        expect(runner.errors.size).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Similar to `CheckSaveReturnValueReview`. Checks for `#destroy` and `#destroy!`.

I used the code from `CheckSaveReturnValueReview` pretty liberally. I'd like to refactor out some of the redundancy, but I wasn't quite able to.