### PR TITLE
Bugfix: Don't suggest multipart content type for plain text emails

### DIFF
--- a/lib/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review.rb
+++ b/lib/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review.rb
@@ -45,6 +45,7 @@ module RailsBestPractices
         # @param [String] name method name in action_mailer
         def rails2_canonical_mailer_views?(name)
           return true if mailer_files(name).length == 0
+          return true if mailer_files(name).none? { |filename| filename.index 'text.html' }
           mailer_files(name).any? { |filename| filename.index 'text.html' } &&
             mailer_files(name).any? { |filename| filename.index 'text.plain' }
         end
@@ -54,6 +55,7 @@ module RailsBestPractices
         # @param [String] name method name in action_mailer
         def rails3_canonical_mailer_views?(name)
           return true if mailer_files(name).length == 0
+          return true if mailer_files(name).none? { |filename| filename.index 'html' }
           mailer_files(name).any? { |filename| filename.index 'html' } &&
             mailer_files(name).any? { |filename| filename.index 'text' }
         end

--- a/spec/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review_spec.rb
+++ b/spec/rails_best_practices/reviews/use_multipart_alternative_as_content_type_of_email_review_spec.rb
@@ -52,11 +52,10 @@ GEM
               expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
             end
 
-            it "should use multiple/alternative as content_type of email when only plain text" do
+            it "should not use multiple/alternative as content_type of email when only plain text" do
               mock_email_files(["send_email.text.plain.erb"])
               runner.review('app/mailers/project_mailer.rb', content)
-              expect(runner.errors.size).to eq(1)
-              expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
+              expect(runner.errors.size).to eq(0)
             end
 
             it "should not use multipart/alternative as content_type of email" do
@@ -74,11 +73,10 @@ GEM
               expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
             end
 
-            it "should use multiple/alternative as content_type of email when only plain text" do
+            it "should not use multiple/alternative as content_type of email when only plain text" do
               mock_email_files(["send_email.text.plain.haml"])
               runner.review('app/mailers/project_mailer.rb', content)
-              expect(runner.errors.size).to eq(1)
-              expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
+              expect(runner.errors.size).to eq(0)
             end
 
             it "should not use multipart/alternative as content_type of email" do
@@ -96,11 +94,10 @@ GEM
               expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
             end
 
-            it "should use multiple/alternative as content_type of email when only plain text" do
+            it "should not use multiple/alternative as content_type of email when only plain text" do
               mock_email_files(["send_email.text.plain.slim"])
               runner.review('app/mailers/project_mailer.rb', content)
-              expect(runner.errors.size).to eq(1)
-              expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
+              expect(runner.errors.size).to eq(0)
             end
 
             it "should not use multipart/alternative as content_type of email" do
@@ -118,11 +115,10 @@ GEM
               expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
             end
 
-            it "should use multiple/alternative as content_type of email when only plain text" do
+            it "should not use multiple/alternative as content_type of email when only plain text" do
               mock_email_files(["send_email.text.plain.rhtml"])
               runner.review('app/mailers/project_mailer.rb', content)
-              expect(runner.errors.size).to eq(1)
-              expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
+              expect(runner.errors.size).to eq(0)
             end
 
             it "should not use multipart/alternative as content_type of email" do
@@ -187,11 +183,10 @@ GEM
               expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
             end
 
-            it "should use multiple/alternative as content_type of email when only plain text" do
+            it "should not use multiple/alternative as content_type of email when only plain text" do
               mock_email_files(["send_email.text.erb"])
               runner.review('app/mailers/project_mailer.rb', content)
-              expect(runner.errors.size).to eq(1)
-              expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
+              expect(runner.errors.size).to eq(0)
             end
 
             it "should not use multipart/alternative as content_type of email" do
@@ -209,11 +204,10 @@ GEM
               expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
             end
 
-            it "should use multiple/alternative as content_type of email when only plain text" do
+            it "should not use multiple/alternative as content_type of email when only plain text" do
               mock_email_files(["send_email.text.haml"])
               runner.review('app/mailers/project_mailer.rb', content)
-              expect(runner.errors.size).to eq(1)
-              expect(runner.errors[0].to_s).to eq("app/mailers/project_mailer.rb:2 - use multipart/alternative as content_type of email")
+              expect(runner.errors.size).to eq(0)
             end
 
             it "should not use multipart/alternative as content_type of email" do


### PR DESCRIPTION
If you only want to send plain text emails, Rails BP shouldn't force you to add HTML variants.