### PR TITLE
 Add Editor Integration Section for TextMate 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ or add it to the Gemfile
 
 Install <https://github.com/asuth/subl-handler>
 
+## Editor Integration
+
+#### TextMate 2
+
+If you use `TextMate 2`, you can install the [RailsBestPractices.tmbundle](https://github.com/jjuliano/RailsBestPractices.tmbundle) bundle.
+
 ## Issues
 
 If you install the rails_best_practices with bundler-installed GitHub-sourced gem, please use the following command instead.


### PR DESCRIPTION
Add RailsBestPractices.tmbundle TextMate 2 bundle that utilize the rails_best_practices gem.