### PR TITLE
Standarized exit code

### DIFF
--- a/lib/rails_best_practices/command.rb
+++ b/lib/rails_best_practices/command.rb
@@ -142,5 +142,5 @@ else
   analyzer = RailsBestPractices::Analyzer.new(ARGV.first, options)
   analyzer.analyze
   analyzer.output
-  exit analyzer.runner.errors.size
+  exit analyzer.runner.errors.size > 0 ? 1 : 0
 end


### PR DESCRIPTION
Hey, up until now the exit code was equal to the number of errors found. I don't think it is right as exit  codes aren't meant to be used that way. What I suggest is to make them similar to Rubocop: 0 for no offenses and 1 for 1 or more.