### PR TITLE
Updated readme due to --config + support for general (not app based) configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To see the full list of command-line options, run:
         -o, --only PATTERNS              analyze files only matching a pattern
                                          (comma-separated regexp list)
         -g, --generate                   Generate configuration yaml
+        -c, --config CONFIG_PATH         configuration file location (defaults to config/rails_best_practices.yml)
         -v, --version                    Show this version
         -h, --help                       Show this message
 

--- a/lib/rails_best_practices/core/runner.rb
+++ b/lib/rails_best_practices/core/runner.rb
@@ -44,7 +44,7 @@ module RailsBestPractices
       #
       # @return [String] the config path
       def self.config_path
-        custom_config = File.join(Runner.base_path, @config_path || 'config/rails_best_practices.yml')
+        custom_config = @config_path || File.join(Runner.base_path, 'config/rails_best_practices.yml')
         File.exists?(custom_config) ? custom_config : RailsBestPractices::Analyzer::DEFAULT_CONFIG
       end
 


### PR DESCRIPTION
Hello,

Sorry this update (it should go together with the previous one). I switched the --config option to handle configurations that are not only in the project location but also outside. This was my case in the first place - I've wanted to have a general config on the CI that would handle all the apps.

Sorry for this inconvenience. 